### PR TITLE
Poetry init and configures CLI entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/

--- a/msr/cli.py
+++ b/msr/cli.py
@@ -1,0 +1,9 @@
+"""Entry point for the CLI
+
+@author Rory Byrne <rory@rory.bio>
+"""
+
+
+def msr():
+    """CLI entry point"""
+    print("msr entrypoint")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "msr"
+version = "0.1.0"
+description = "A CLI tool to measure remote web pages and domains"
+authors = ["synek <rory@rory.bio>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+msr = "msr.cli:msr"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
What does this PR do?
=========================
* Initialize the repository as a poetry project
* Adds a cli.py file containing the entrypoint
* Configures the entrypoint in the pyproject.toml file

Why are we doing this?
======================
* So that we can quickly run msr from the command line

Notes
=====
Closes #1